### PR TITLE
Fix up invalid option for markdown parser

### DIFF
--- a/rss2telegram.go
+++ b/rss2telegram.go
@@ -24,7 +24,7 @@ var (
 	// client is a global Firestore client, initialized once per instance.
 	client    *firestore.Client
 	converter = md.NewConverter("", true, &md.Options{
-		StrongDelimiter: "*",
+		EmDelimiter: "*",
 	})
 )
 


### PR DESCRIPTION
While I'm trying this tool, I notice that there's an error message:

```markdown options is not valid: field must be one of [** __] but got *```

Having a quick look on [html-to-markdown's doc](https://godoc.org/github.com/JohannesKaufmann/html-to-markdown#Options), I think `EmDelimiter` should be used instead.